### PR TITLE
修复有序序列的序号显示错误问题

### DIFF
--- a/happysimple/source/happysimple-set.css
+++ b/happysimple/source/happysimple-set.css
@@ -744,18 +744,22 @@ li {
     margin: 0px 0px 0px var(--order-list-li-indentation);
 }
 
-#write ol>li:before {
+#write ol>li::before {
     position: absolute;
     color: var(--order-list-sign-color);
     content: counter(li) ".";
-    counter-increment: li;
+    counter-increment: li 1;
     width: 22px;
     text-align: right;
     left: -12px;
 }
 
-#write ol li:first-child {
-    counter-reset: li;
+#write ol[start=""] {
+    counter-reset: li 0;
+}
+
+#write ol {
+    counter-reset: unset;
 }
 /* --------------------------------------------------------------------------------------- */
 

--- a/happysimple/source/happysimple-set.css
+++ b/happysimple/source/happysimple-set.css
@@ -754,7 +754,8 @@ li {
     left: -12px;
 }
 
-#write ol[start=""] {
+#write ol[start=""],
+#write ol:not([start]) {
     counter-reset: li 0;
 }
 


### PR DESCRIPTION
在有序序列中间断开插入内容后，手动添加继上序列后续序号显示错误都是从1开始。

例如 typora 输入 ：

```
1. 序号1

内容1

2. 序号2
```

显示结果：

```
1. 序号1

内容1

1. 序号2
```

注意目前只能解决 **从1开始的有序序列** 显示错误问题，当序列是非1开始的序列时依然会从 **1开始显示** 。

例如 typora 输入 ：

```
3. 序号3

内容1

4. 序号4
```

显示结果：

```
1. 序号3

内容1

2. 序号4
```